### PR TITLE
Replace xhtml2pdf with WeasyPrint

### DIFF
--- a/coding/survey_analysis_mvp/README.md
+++ b/coding/survey_analysis_mvp/README.md
@@ -20,10 +20,8 @@
 
 PDFやグラフで日本語を正しく表示するため、事前に日本語フォントを準備します。
 `fonts` フォルダに **TTF/OTF 形式** の `NotoSansJP-Regular.otf` を置くことを推奨します。
-Windows の既存フォント (Meiryo など) も利用できますが、これらは `.ttc` 形式で
-あるため `xhtml2pdf` では読み込めず、PDF作成時に "Can't open file" エラーが発生
-する場合があります。Noto Sans JP は [Google Fonts](https://fonts.google.com/noto/specimen/Noto+Sans+JP)
-から入手できます。
+Windows の既存フォント (Meiryo など) も利用できます。PDF生成には `WeasyPrint` を使用しており、`.ttc` 形式のフォントも利用可能です。
+Noto Sans JP は [Google Fonts](https://fonts.google.com/noto/specimen/Noto+Sans+JP) から入手できます。
 
 ### ステップ2: APIキーの設定
 

--- a/coding/survey_analysis_mvp/requirements.txt
+++ b/coding/survey_analysis_mvp/requirements.txt
@@ -2,7 +2,7 @@ pandas
 openpyxl
 customtkinter
 wordcloud
-xhtml2pdf
+weasyprint
 matplotlib
 jinja2
 spacy


### PR DESCRIPTION
## Summary
- switch PDF generation to WeasyPrint
- update PDF CSS handling
- install WeasyPrint instead of xhtml2pdf
- document new requirement in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r coding/survey_analysis_mvp/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68664fb13f78833386d54bd579e9fa0b