### PR TITLE
Add font requirement notice and check

### DIFF
--- a/coding/survey_analysis_mvp/README.md
+++ b/coding/survey_analysis_mvp/README.md
@@ -20,6 +20,7 @@
 
 PDFやグラフで日本語を正しく表示するため、事前に日本語フォントを準備します。
 `fonts` フォルダに **TTF/OTF 形式** の `NotoSansJP-Regular.otf` を置くことを推奨します。
+**重要**: PDFレポート生成前にこのファイルが存在しないとエラーになります。必ず配置してください。
 Windows の既存フォント (Meiryo など) も利用できます。PDF生成には `WeasyPrint` を使用しており、`.ttc` 形式のフォントも利用可能です。
 Noto Sans JP は [Google Fonts](https://fonts.google.com/noto/specimen/Noto+Sans+JP) から入手できます。
 
@@ -74,6 +75,8 @@ python main.py
 
 - **グラフやPDFの日本語が四角（豆腐）になる:**
   - Windowsの日本語フォントが利用できないか、`fonts`フォルダにフォントが配置されていない可能性があります。必要に応じて`NotoSansJP-Regular.otf`を配置してください。
+- **PDF生成でFileNotFoundErrorが出る:**
+  - `fonts/NotoSansJP-Regular.otf` が存在するか確認してください。
 
 - **アプリケーションが起動しない:**
   - 「ステップ3: 必要なライブラリのインストール」が正しく完了しているか確認してください。再度 `pip install -r requirements.txt` を実行してみてください。

--- a/coding/survey_analysis_mvp/reporting.py
+++ b/coding/survey_analysis_mvp/reporting.py
@@ -210,6 +210,8 @@ def create_emotion_radar_chart_base64(emotion_avg: dict) -> str:
 
 def generate_pdf_report(summary_data: dict, output_path: str):
     """集計データからPDFレポートを生成する"""
+    if not os.path.exists(FONT_PATH):
+        raise FileNotFoundError("Required font file not found: {}. Please download NotoSansJP-Regular.otf and place it in the fonts directory before generating PDFs.".format(FONT_PATH))
     sentiment_chart = create_sentiment_pie_chart_base64(
         summary_data.get('sentiment_counts', pd.Series())
     )


### PR DESCRIPTION
## Summary
- highlight that a font file must exist before creating PDFs
- detect missing `NotoSansJP-Regular.otf` in `generate_pdf_report`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r coding/survey_analysis_mvp/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6866514fefd48333998f862006664f6c