### PR TITLE
Fix PDF HTML reporting

### DIFF
--- a/coding/survey_analysis_mvp/reporting.py
+++ b/coding/survey_analysis_mvp/reporting.py
@@ -5,10 +5,17 @@ import base64
 import os
 import pandas as pd
 from jinja2 import Environment, FileSystemLoader
-from fpdf import FPDF
+from fpdf import FPDF, HTMLMixin
 from pathlib import Path
 from wordcloud import WordCloud
 import warnings
+
+
+class PDF(FPDF, HTMLMixin):
+    """Custom PDF class with basic HTML support."""
+
+    pass
+
 
 import math
 from typing import Optional
@@ -18,8 +25,6 @@ FONT_DIR = os.path.join(os.path.dirname(__file__), "fonts")
 FONT_PATH_TTF = os.path.join(FONT_DIR, "NotoSansJP-Regular.ttf")
 FONT_PATH_OTF = os.path.join(FONT_DIR, "NotoSansJP-Regular.otf")
 FONT_PATH = FONT_PATH_TTF if os.path.exists(FONT_PATH_TTF) else FONT_PATH_OTF
-
-
 
 
 def find_japanese_font() -> Optional[str]:
@@ -56,7 +61,9 @@ def find_japanese_font() -> Optional[str]:
             continue
 
     if found_ttc:
-        warnings.warn("Only .ttc fonts were found. These may not work with some PDF libraries.")
+        warnings.warn(
+            "Only .ttc fonts were found. These may not work with some PDF libraries."
+        )
 
     return None
 
@@ -67,18 +74,20 @@ AVAILABLE_FONT_PATH = find_japanese_font()
 def set_japanese_font() -> bool:
     """matplotlibに日本語フォントを設定する"""
     if not AVAILABLE_FONT_PATH:
-        mpl.rcParams['axes.unicode_minus'] = False
+        mpl.rcParams["axes.unicode_minus"] = False
         return False
 
     try:
         mpl.font_manager.fontManager.addfont(AVAILABLE_FONT_PATH)
-        font_name = mpl.font_manager.FontProperties(fname=AVAILABLE_FONT_PATH).get_name()
-        mpl.rcParams['font.family'] = font_name
-        mpl.rcParams['font.sans-serif'] = [font_name]
+        font_name = mpl.font_manager.FontProperties(
+            fname=AVAILABLE_FONT_PATH
+        ).get_name()
+        mpl.rcParams["font.family"] = font_name
+        mpl.rcParams["font.sans-serif"] = [font_name]
     except Exception:
         return False
 
-    mpl.rcParams['axes.unicode_minus'] = False
+    mpl.rcParams["axes.unicode_minus"] = False
     return True
 
 
@@ -88,16 +97,23 @@ def create_sentiment_pie_chart_base64(sentiment_counts: pd.Series) -> str:
         return ""
 
     fig, ax = plt.subplots()
-    ax.pie(sentiment_counts, labels=sentiment_counts.index, autopct='%1.1f%%', startangle=90, colors=['#4CAF50', '#FFC107', '#F44336', '#9E9E9E'])
-    ax.axis('equal')
-    ax.set_title('感情分析サマリー')
+    ax.pie(
+        sentiment_counts,
+        labels=sentiment_counts.index,
+        autopct="%1.1f%%",
+        startangle=90,
+        colors=["#4CAF50", "#FFC107", "#F44336", "#9E9E9E"],
+    )
+    ax.axis("equal")
+    ax.set_title("感情分析サマリー")
 
     buffer = io.BytesIO()
-    plt.savefig(buffer, format='png', bbox_inches='tight')
+    plt.savefig(buffer, format="png", bbox_inches="tight")
     buffer.seek(0)
     plt.close(fig)
 
-    return base64.b64encode(buffer.getvalue()).decode('utf-8')
+    return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
 
 def create_topics_bar_chart_base64(topic_counts: pd.Series) -> str:
     """トピックの出現頻度から棒グラフを生成し、Base64エンコードされたPNG文字列を返す"""
@@ -105,17 +121,18 @@ def create_topics_bar_chart_base64(topic_counts: pd.Series) -> str:
         return ""
 
     fig, ax = plt.subplots(figsize=(10, 8))
-    topic_counts.sort_values().plot(kind='barh', ax=ax)
-    ax.set_title('主要トピック Top 15')
-    ax.set_xlabel('出現回数')
+    topic_counts.sort_values().plot(kind="barh", ax=ax)
+    ax.set_title("主要トピック Top 15")
+    ax.set_xlabel("出現回数")
     plt.tight_layout()
 
     buffer = io.BytesIO()
-    plt.savefig(buffer, format='png')
+    plt.savefig(buffer, format="png")
     buffer.seek(0)
     plt.close(fig)
 
-    return base64.b64encode(buffer.getvalue()).decode('utf-8')
+    return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
 
 def create_moderation_bar_chart_base64(moderation_summary: dict) -> str:
     """モデレーション結果から棒グラフを生成し、Base64エンコードされたPNG文字列を返す"""
@@ -126,18 +143,19 @@ def create_moderation_bar_chart_base64(moderation_summary: dict) -> str:
     values = list(moderation_summary.values())
 
     fig, ax = plt.subplots(figsize=(10, 6))
-    ax.bar(labels, values, color='skyblue')
-    ax.set_title('モデレーション結果サマリー')
-    ax.set_ylabel('フラグ数')
-    plt.xticks(rotation=45, ha='right')
+    ax.bar(labels, values, color="skyblue")
+    ax.set_title("モデレーション結果サマリー")
+    ax.set_ylabel("フラグ数")
+    plt.xticks(rotation=45, ha="right")
     plt.tight_layout()
 
     buffer = io.BytesIO()
-    plt.savefig(buffer, format='png', bbox_inches='tight')
+    plt.savefig(buffer, format="png", bbox_inches="tight")
     buffer.seek(0)
     plt.close(fig)
 
-    return base64.b64encode(buffer.getvalue()).decode('utf-8')
+    return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
 
 def create_emotion_radar_chart_base64(emotion_avg: dict) -> str:
     """感情スコアの平均からレーダーチャートを生成し、Base64エンコードされたPNG文字列を返す"""
@@ -149,24 +167,25 @@ def create_emotion_radar_chart_base64(emotion_avg: dict) -> str:
 
     # レーダーチャートの準備
     angles = [n / float(len(labels)) * 2 * math.pi for n in range(len(labels))]
-    angles += angles[:1] # 閉じたグラフにするため最初の要素を最後に追加
+    angles += angles[:1]  # 閉じたグラフにするため最初の要素を最後に追加
     stats += stats[:1]
 
     fig, ax = plt.subplots(figsize=(6, 6), subplot_kw=dict(polar=True))
-    ax.fill(angles, stats, color='red', alpha=0.25)
-    ax.plot(angles, stats, color='red', linewidth=2)
-    ax.set_yticklabels([]) # Y軸のラベルを非表示
+    ax.fill(angles, stats, color="red", alpha=0.25)
+    ax.plot(angles, stats, color="red", linewidth=2)
+    ax.set_yticklabels([])  # Y軸のラベルを非表示
     ax.set_xticks(angles[:-1])
     ax.set_xticklabels(labels)
-    ax.set_ylim(0, 5) # スコアの範囲
-    ax.set_title('感情スコア平均', va='bottom')
+    ax.set_ylim(0, 5)  # スコアの範囲
+    ax.set_title("感情スコア平均", va="bottom")
 
     buffer = io.BytesIO()
-    plt.savefig(buffer, format='png', bbox_inches='tight')
+    plt.savefig(buffer, format="png", bbox_inches="tight")
     buffer.seek(0)
     plt.close(fig)
 
-    return base64.b64encode(buffer.getvalue()).decode('utf-8')
+    return base64.b64encode(buffer.getvalue()).decode("utf-8")
+
 
 def generate_pdf_report(summary_data: dict, output_path: str):
     """集計データからPDFレポートを生成する"""
@@ -175,57 +194,62 @@ def generate_pdf_report(summary_data: dict, output_path: str):
             f"Required font file not found: {FONT_PATH}. Please place NotoSansJP-Regular.ttf in the fonts directory before generating PDFs."
         )
     sentiment_chart = create_sentiment_pie_chart_base64(
-        summary_data.get('sentiment_counts', pd.Series())
+        summary_data.get("sentiment_counts", pd.Series())
     )
     topics_chart = create_topics_bar_chart_base64(
-        summary_data.get('topic_counts', pd.Series())
+        summary_data.get("topic_counts", pd.Series())
     )
     moderation_chart = create_moderation_bar_chart_base64(
-        summary_data.get('moderation_summary', {})
+        summary_data.get("moderation_summary", {})
     )
     emotion_chart = create_emotion_radar_chart_base64(
-        summary_data.get('emotion_avg', {})
+        summary_data.get("emotion_avg", {})
     )
 
-    env = Environment(loader=FileSystemLoader('.'))
-    template = env.get_template('report_template.html')
-    font_uri = Path(AVAILABLE_FONT_PATH).resolve().as_uri() if AVAILABLE_FONT_PATH else ""
+    env = Environment(loader=FileSystemLoader("."))
+    template = env.get_template("report_template.html")
+    font_uri = (
+        Path(AVAILABLE_FONT_PATH).resolve().as_uri() if AVAILABLE_FONT_PATH else ""
+    )
     html_out = template.render(
         sentiment_chart_base64=sentiment_chart,
         topics_chart_base64=topics_chart,
         moderation_chart_base64=moderation_chart,
         emotion_chart_base64=emotion_chart,
-        topic_table=summary_data.get('topic_counts', pd.Series()).to_frame().to_html(header=False),
-        font_path=font_uri
+        topic_table=summary_data.get("topic_counts", pd.Series())
+        .to_frame()
+        .to_html(header=False),
+        font_path=font_uri,
     )
 
-    pdf = FPDF()
+    pdf = PDF()
     pdf.add_page()
     if AVAILABLE_FONT_PATH:
-        pdf.add_font('NotoSansJP', '', AVAILABLE_FONT_PATH, uni=True)
-        pdf.set_font('NotoSansJP', '', 12)
+        pdf.add_font("NotoSansJP", "", AVAILABLE_FONT_PATH, uni=True)
+        pdf.set_font("NotoSansJP", "", 12)
     pdf.write_html(html_out)
     pdf.output(output_path)
     print(f"PDFレポートが '{output_path}' として生成されました。")
+
 
 def generate_wordcloud(words: list, output_path: str):
     """単語リストからワードクラウド画像を生成・保存する"""
     if not words:
         print("ワードクラウドを生成するための単語がありません。")
         return
-    
+
     font_path = AVAILABLE_FONT_PATH
     if not font_path:
         print("日本語フォントが見つからないため、ワードクラウドを生成できません。")
         return
 
     wordcloud = WordCloud(
-        width=800, 
-        height=400, 
-        background_color='white',
+        width=800,
+        height=400,
+        background_color="white",
         font_path=font_path,
-        collocations=False # 単語のペアを考慮しない
-    ).generate(' '.join(words))
+        collocations=False,  # 単語のペアを考慮しない
+    ).generate(" ".join(words))
 
     wordcloud.to_file(output_path)
     print(f"ワードクラウドが '{output_path}' として保存されました。")

--- a/coding/survey_analysis_mvp/requirements.txt
+++ b/coding/survey_analysis_mvp/requirements.txt
@@ -2,7 +2,7 @@ pandas
 openpyxl
 customtkinter
 wordcloud
-fpdf2
+fpdf2>=2.7
 matplotlib
 jinja2
 spacy


### PR DESCRIPTION
## Summary
- enable HTML support for PDF reports with fpdf2
- require fpdf2>=2.7

## Testing
- `pytest -q`
- `black --check coding/survey_analysis_mvp/reporting.py`


------
https://chatgpt.com/codex/tasks/task_e_68669006a3d88333a02781e1cd247473