### PR TITLE
Fix PDF unescape error

### DIFF
--- a/coding/survey_analysis_mvp/README.md
+++ b/coding/survey_analysis_mvp/README.md
@@ -41,6 +41,15 @@ Noto Sans JP は [Google Fonts](https://fonts.google.com/noto/specimen/Noto+Sans
 pip install -r requirements.txt
 ```
 
+> **補足:** もし `HTML2PDF object has no attribute 'unescape'` というエラーが表示される場合は、
+> 古い `fpdf` パッケージがインストールされている可能性があります。次のコマンドで削除してから
+> `fpdf2` を再インストールしてください。
+>
+> ```bash
+> pip uninstall fpdf
+> pip install --upgrade fpdf2
+> ```
+
 ## 3. アプリケーションの起動方法
 
 ターミナルで以下のコマンドを実行します。

--- a/coding/survey_analysis_mvp/reporting.py
+++ b/coding/survey_analysis_mvp/reporting.py
@@ -5,10 +5,17 @@ import base64
 import os
 import pandas as pd
 from jinja2 import Environment, FileSystemLoader
-from fpdf import FPDF, HTMLMixin
+from fpdf import FPDF, HTMLMixin, __version__ as fpdf_version
+from packaging import version
 from pathlib import Path
 from wordcloud import WordCloud
 import warnings
+
+if version.parse(fpdf_version).major < 2:
+    raise ImportError(
+        f"fpdf2>=2 is required but version {fpdf_version} was found.\n"
+        "Please uninstall the old 'fpdf' package and install 'fpdf2'."
+    )
 
 
 class PDF(FPDF, HTMLMixin):


### PR DESCRIPTION
## Summary
- prevent running with old `fpdf` by checking version at runtime
- add troubleshooting instructions about uninstalling the legacy `fpdf` package

## Testing
- `python -m py_compile coding/survey_analysis_mvp/reporting.py`


------
https://chatgpt.com/codex/tasks/task_e_68669216c1a08333a8e233d0a0552773