### PR TITLE
Update testing instructions for non-ASCII paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ For detailed setup and usage instructions, see [coding/survey_analysis_mvp/READM
 - **Fonts:** NotoSansJP Regular and Bold fonts are already provided under `coding/survey_analysis_mvp/fonts/`. If you wish to replace them, add TTF or OTF versions of `NotoSansJP-Regular` and `NotoSansJP-Bold` to that folder.
 - **API key:** Set `OPENAI_API_KEY` in your environment or in a `.env` file so the application can access the OpenAI API.
 
+### Testing
+
+To verify that all Python modules are syntactically correct even when file paths
+contain non-ASCII characters, run:
+
+```bash
+python scripts/compile_all.py
+```
+
+This script gathers all `*.py` files using `pathlib` and compiles each one with
+`py_compile`, ensuring paths with Japanese characters are handled reliably.
+

--- a/coding/AGENT.md
+++ b/coding/AGENT.md
@@ -293,6 +293,7 @@ Gemini CLIに高品質で一貫性のある、プロジェクトのアーキテ�
 * **フォーマット:** コードのフォーマットにはBlackを使用します。  
 * **ドキュメンテーション:** 全ての公開関数とクラスには、Googleスタイルのdocstringを記述してください。  
 * **非同期処理:** ネットワークI/Oなど、待機時間が発生する処理にはasync/awaitを積極的に使用してください。
+* **構文チェック:** 非ASCIIパスを含むファイルも確実に検証できるよう、`scripts/compile_all.py` で全 `*.py` ファイルを `py_compile` に掛けるテストを推奨します。
 
 ## **4\. ツール利用時のガイドライン**
 
@@ -432,6 +433,16 @@ io.BytesIOを用いたインメモリでの画像処理、Base64エンコーデ�
 * **定量的分析:** センチメントの内訳、トピックの出現頻度など、matplotlibで生成したグラフや表を掲載するセクション。データの全体像を視覚的に示す。  
 * **定性的深掘り:** LLMによって抽出された主要なテーマごとにセクションを設け、それぞれのテーマを裏付ける代表的なverbatim\_quote（生の声）を複数掲載する。これにより、定量データに質的な文脈と説得力を与える。  
 * **実行可能な提言:** LLMがactionable\_insight: trueと判定した回答をリストアップし、具体的な改善アクションに繋げるためのセクション。
+
+### **3.4. PDF出力ルール**
+
+`pdfmake.md` に基づき、PDFレポート生成は次の手順で実装する。
+
+* `generate_pdf_report(summary_data: dict, output_path: str)` で各グラフ関数から取得したBase64画像を `report_template.html` へ埋め込む。
+* `PDF(FPDF, HTMLMixin)` を使用し、`pdf.add_page()` の直後に `pdf.add_font()` で `NotoSansJP` フォント(通常・太字)を `uni=True` 指定で登録する。
+* その後 `pdf.set_font("NotoSansJP", "", 12)` を設定し、`pdf.write_html()` でHTMLを描画する。
+* フォントファイルが存在しない場合は `FileNotFoundError` を発生させる。
+* `create_sentiment_pie_chart_base64` などのグラフ生成関数は入力が空の場合、空文字列を返す実装とする。
 
 ---
 

--- a/scripts/compile_all.py
+++ b/scripts/compile_all.py
@@ -1,0 +1,10 @@
+import pathlib
+import py_compile
+import sys
+
+for path in pathlib.Path('.').rglob('*.py'):
+    try:
+        py_compile.compile(str(path), doraise=True)
+    except Exception as e:
+        print(f'Failed to compile {path}: {e}', file=sys.stderr)
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- add `scripts/compile_all.py` to compile all Python files
- document how to run syntax checks in README
- note compile script in AGENT instructions

## Testing
- `python scripts/compile_all.py`

------
https://chatgpt.com/codex/tasks/task_e_6872822273408333a55ccc74df3d24df