### PR TITLE
Fix PDF bullet layout

### DIFF
--- a/coding/survey_analysis_mvp/reporting.py
+++ b/coding/survey_analysis_mvp/reporting.py
@@ -103,7 +103,19 @@ class ReportPDF(FPDF):
         self.cell(0, 10, "■ 推奨されるネクストアクション", 0, 1, "L")
         self.set_font("NotoSansJP", "", 10)
         for item in action_items:
-            self.multi_cell(0, 7, f"・ {item}", 0, "L")
+            # multi_cell defaults to positioning the cursor at the end of
+            # the written cell. This causes subsequent calls to fail due to
+            # insufficient width. Explicitly reset the X position to the
+            # left margin and move to the next line after each bullet.
+            self.multi_cell(
+                0,
+                7,
+                f"・ {item}",
+                border=0,
+                align="L",
+                new_x="LMARGIN",
+                new_y="NEXT",
+            )
 
     def create_chart_commentary_page(
         self,


### PR DESCRIPTION
## Summary
- handle bullet items correctly when creating summary page

## Testing
- `python scripts/compile_all.py`
- `python - <<'EOF'
from coding.survey_analysis_mvp.reporting import generate_pdf_report
import pandas as pd
summary_data={
    'analysis_target': 'テスト',
    'summary_text': '概要',
    'action_items': ['A','B'],
    'sentiment_counts': pd.Series({'Positive':5,'Negative':3,'Neutral':2}),
    'sentiment_commentary':'コメント',
    'topic_counts': pd.Series({'A':10,'B':5,'C':2}),
    'topics_commentary':'トピックコメント'
}

generate_pdf_report(summary_data,'test.pdf')
print('done')
EOF

------
https://chatgpt.com/codex/tasks/task_e_6877402386908333910a30636e839fa1