### PR TITLE
Handle optional GCP secrets

### DIFF
--- a/coding/survey_analysis_mvp/config.py
+++ b/coding/survey_analysis_mvp/config.py
@@ -4,7 +4,10 @@ from typing import Optional
 
 # Google Cloud Secret Managerクライアントをインポート
 # pip install google-cloud-secret-manager
-from google.cloud import secretmanager
+try:
+    from google.cloud import secretmanager
+except ImportError:  # pragma: no cover - optional dependency
+    secretmanager = None
 
 class AppSettings(BaseSettings):
     # .envファイルからの読み込みを有効にする
@@ -24,6 +27,10 @@ class AppSettings(BaseSettings):
 
     def _load_secrets_from_gcp(self):
         """本番環境の場合、GCP Secret Managerから機密情報を読み込む"""
+        if secretmanager is None:
+            raise RuntimeError(
+                "google-cloud-secret-manager is required to load secrets from GCP"
+            )
         if not self.GCP_PROJECT_ID:
             print("警告: 本番環境ですが、GCP_PROJECT_IDが設定されていません。")
             return

--- a/coding/survey_analysis_mvp/requirements.txt
+++ b/coding/survey_analysis_mvp/requirements.txt
@@ -13,3 +13,4 @@ pydantic
 openai
 pydantic-settings
 python-dotenv
+google-cloud-secret-manager


### PR DESCRIPTION
## Summary
- support optional google cloud secret manager dependency
- avoid import errors in production configuration
- declare google-cloud-secret-manager in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b7a8ddfc833399ea556572f1e19d