### PR TITLE
Refactor with GUI and WeasyPrint

### DIFF
--- a/coding/survey_analysis_mvp/app.py
+++ b/coding/survey_analysis_mvp/app.py
@@ -1,0 +1,96 @@
+import customtkinter as ctk
+from tkinter import filedialog, messagebox
+import pandas as pd
+import os
+
+from analysis import analyze_survey
+from reporting import create_report
+
+
+class App(ctk.CTk):
+    def __init__(self):
+        super().__init__()
+
+        self.title("アンケート分析レポート生成ツール")
+        ctk.set_appearance_mode("System")
+        ctk.set_default_color_theme("blue")
+        self.geometry("600x400")
+
+        self.file_path = ""
+
+        # file frame
+        file_frame = ctk.CTkFrame(self)
+        file_frame.pack(padx=20, pady=10, fill="x")
+        ctk.CTkLabel(file_frame, text="1. 分析対象のExcelファイルを選択").pack(anchor="w")
+        inner = ctk.CTkFrame(file_frame)
+        inner.pack(fill="x")
+        self.file_entry = ctk.CTkEntry(inner, state="disabled", width=400)
+        self.file_entry.pack(side="left", padx=5, pady=5, fill="x", expand=True)
+        ctk.CTkButton(inner, text="ファイルを選択", command=self.select_file).pack(side="left", padx=5)
+
+        # column frame
+        column_frame = ctk.CTkFrame(self)
+        column_frame.pack(padx=20, pady=10, fill="x")
+        ctk.CTkLabel(column_frame, text="2. 分析対象の列名を入力").pack(anchor="w")
+        self.column_entry = ctk.CTkEntry(column_frame)
+        self.column_entry.pack(fill="x", padx=5, pady=5)
+
+        # wordcloud type frame
+        wc_frame = ctk.CTkFrame(self)
+        wc_frame.pack(padx=20, pady=10, fill="x")
+        ctk.CTkLabel(wc_frame, text="3. ワードクラウドの種類を選択").pack(anchor="w")
+        self.wc_var = ctk.StringVar(value="positive")
+        options = [("ノーマル", "normal"), ("ポジティブ", "positive"), ("ネガティブ", "negative")]
+        btn_frame = ctk.CTkFrame(wc_frame)
+        btn_frame.pack(pady=5)
+        for text, val in options:
+            ctk.CTkRadioButton(btn_frame, text=text, variable=self.wc_var, value=val).pack(side="left", padx=10)
+
+        # run frame
+        run_frame = ctk.CTkFrame(self)
+        run_frame.pack(padx=20, pady=20, fill="x")
+        self.run_button = ctk.CTkButton(run_frame, text="レポート生成開始", command=self.run)
+        self.run_button.pack(pady=5)
+        self.progress = ctk.CTkProgressBar(run_frame)
+        self.progress.set(0)
+        self.progress.pack(fill="x", padx=5, pady=5)
+        self.status = ctk.CTkLabel(run_frame, text="準備完了")
+        self.status.pack()
+
+    def select_file(self):
+        path = filedialog.askopenfilename(filetypes=[("Excel files", "*.xlsx")])
+        if path:
+            self.file_path = path
+            self.file_entry.configure(state="normal")
+            self.file_entry.delete(0, "end")
+            self.file_entry.insert(0, path)
+            self.file_entry.configure(state="disabled")
+
+    def run(self):
+        if not self.file_path:
+            messagebox.showerror("エラー", "Excelファイルを選択してください")
+            return
+        column = self.column_entry.get().strip()
+        if not column:
+            messagebox.showerror("エラー", "列名を入力してください")
+            return
+
+        self.run_button.configure(state="disabled")
+        self.status.configure(text="分析中...")
+        self.update()
+        try:
+            df, pos_sum, neg_sum = analyze_survey(self.file_path, column)
+            self.status.configure(text="レポート生成中...")
+            self.update()
+            create_report(df, pos_sum, neg_sum, self.wc_var.get(), column)
+            self.status.configure(text="完了")
+            messagebox.showinfo("完了", "レポートを output フォルダに保存しました")
+        except Exception as e:
+            messagebox.showerror("エラー", str(e))
+        finally:
+            self.run_button.configure(state="normal")
+
+
+if __name__ == "__main__":
+    app = App()
+    app.mainloop()

--- a/coding/survey_analysis_mvp/report_template.html
+++ b/coding/survey_analysis_mvp/report_template.html
@@ -3,49 +3,7 @@
 <head>
   <title>分析サマリーレポート</title>
   <meta charset="UTF-8">
-  <style>
-    @font-face {
-        font-family: 'NotoSansJP';
-        src: url("{{ font_path }}");
-    }
-    body {
-        font-family: 'NotoSansJP', sans-serif;
-        line-height: 1.6;
-        color: #333;
-    }
-    h1, h2 {
-        color: #2c3e50;
-        border-bottom: 2px solid #3498db;
-        padding-bottom: 10px;
-    }
-    .container {
-        padding: 20px;
-    }
-    .chart-container {
-        text-align: center;
-        margin: 30px 0;
-        page-break-inside: avoid;
-    }
-    .chart-container img {
-        max-width: 90%;
-        height: auto;
-    }
-    .table-container {
-        margin-top: 20px;
-    }
-    table {
-        width: 100%;
-        border-collapse: collapse;
-    }
-    th, td {
-        border: 1px solid #ddd;
-        padding: 8px;
-        text-align: left;
-    }
-    th {
-        background-color: #f2f2f2;
-    }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="container">
@@ -53,12 +11,12 @@
     
     <h2>感情分析</h2>
     <div class="chart-container">
-      <img src="data:image/png;base64,{{ sentiment_chart_base64 }}" alt="感情分析グラフ" />
+      <img src="{{ sentiment_chart_path }}" alt="感情分析グラフ" />
     </div>
 
     <h2>主要トピック</h2>
     <div class="chart-container">
-      <img src="data:image/png;base64,{{ topics_chart_base64 }}" alt="主要トピックグラフ" />
+      <img src="{{ wordcloud_path }}" alt="ワードクラウド" />
     </div>
     
     <div class="table-container">

--- a/coding/survey_analysis_mvp/requirements.txt
+++ b/coding/survey_analysis_mvp/requirements.txt
@@ -4,6 +4,8 @@ customtkinter
 wordcloud
 fpdf2>=2.7
 matplotlib
+seaborn
+weasyprint
 jinja2
 spacy
 sudachipy

--- a/coding/survey_analysis_mvp/style.css
+++ b/coding/survey_analysis_mvp/style.css
@@ -1,0 +1,22 @@
+@font-face {
+    font-family: 'NotoSansJP';
+    src: url('fonts/NotoSansJP-Regular.otf');
+}
+body {
+    font-family: 'NotoSansJP', sans-serif;
+    margin: 2cm;
+}
+header, footer {
+    text-align: center;
+}
+section {
+    margin-bottom: 20px;
+}
+img {
+    max-width: 100%;
+    height: auto;
+}
+@page {
+    size: A4;
+    margin: 2cm;
+}


### PR DESCRIPTION
## Summary
- implement `analyze_survey` for simple Excel sentiment analysis
- introduce `create_report` using WeasyPrint
- add `app.py` GUI with file selection and wordcloud options
- style report with new `style.css`
- update requirements

## Testing
- `python scripts/compile_all.py`

------
https://chatgpt.com/codex/tasks/task_e_6885d2e870288333895cdc551c064ac6