### PR TITLE
Add header/footer and two-column layout for PDF reports

### DIFF
--- a/coding/survey_analysis_mvp/report_template.html
+++ b/coding/survey_analysis_mvp/report_template.html
@@ -6,19 +6,37 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="container">
+  <header>
     <h1>アンケート一括分析 サマリーレポート</h1>
-    
-    <h2>感情分析</h2>
-    <div class="chart-container">
-      <img src="{{ sentiment_chart_path }}" alt="感情分析グラフ" />
+  </header>
+  <div class="container">
+
+    <div class="two-column">
+      <div>
+        <h2>感情分析</h2>
+        <div class="chart-container">
+          <img src="{{ sentiment_chart_path }}" alt="感情分析グラフ" />
+        </div>
+      </div>
+      <section>
+        <h2>ポジティブ要約</h2>
+        <p>{{ positive_summary }}</p>
+      </section>
     </div>
 
-    <h2>主要トピック</h2>
-    <div class="chart-container">
-      <img src="{{ wordcloud_path }}" alt="ワードクラウド" />
+    <div class="two-column">
+      <div>
+        <h2>主要トピック</h2>
+        <div class="chart-container">
+          <img src="{{ wordcloud_path }}" alt="ワードクラウド" />
+        </div>
+      </div>
+      <section>
+        <h2>ネガティブ要約</h2>
+        <p>{{ negative_summary }}</p>
+      </section>
     </div>
-    
+
     <div class="table-container">
         <h3>トピック一覧</h3>
         {{ topic_table|safe }}
@@ -34,16 +52,7 @@
       <img src="data:image/png;base64,{{ emotion_chart_base64 }}" alt="感情スコア平均グラフ" />
     </div>
 
-    <section>
-      <h2>ポジティブ要約</h2>
-      <p>{{ positive_summary }}</p>
-    </section>
-
-    <section>
-      <h2>ネガティブ要約</h2>
-      <p>{{ negative_summary }}</p>
-    </section>
-
   </div>
+  <footer></footer>
 </body>
 </html>

--- a/coding/survey_analysis_mvp/style.css
+++ b/coding/survey_analysis_mvp/style.css
@@ -6,8 +6,21 @@ body {
     font-family: 'NotoSansJP', sans-serif;
     margin: 2cm;
 }
-header, footer {
+
+header {
     text-align: center;
+    margin-bottom: 20px;
+    position: running(header);
+}
+
+footer {
+    text-align: center;
+    font-size: 0.8em;
+    position: running(footer);
+}
+
+footer::after {
+    content: counter(page);
 }
 section {
     margin-bottom: 20px;
@@ -16,7 +29,22 @@ img {
     max-width: 100%;
     height: auto;
 }
+
+.two-column {
+    display: flex;
+    gap: 20px;
+}
+
+.two-column > * {
+    flex: 1;
+}
 @page {
     size: A4;
     margin: 2cm;
+    @top-center {
+        content: element(header);
+    }
+    @bottom-center {
+        content: element(footer);
+    }
 }


### PR DESCRIPTION
## Summary
- enhance `style.css` with running header/footer and two-column layout
- update HTML template to use the new layout and header/footer
- verify PDF generation via WeasyPrint

## Testing
- `python scripts/compile_all.py`
- `python - <<'PY'
from coding.survey_analysis_mvp.reporting import create_report
import pandas as pd
texts=['サービスが良かった','価格が高い','普通']
sentiments=['positive','negative','neutral']
df=pd.DataFrame({'text':texts,'sentiment':sentiments})
create_report(df,'ポジティブ面の概要','ネガティブ面の概要','normal','text')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6885e9495ff08333a3818b30ab9266c8