### PR TITLE
Generate separate positive/negative wordclouds

### DIFF
--- a/coding/survey_analysis_mvp/report_template.html
+++ b/coding/survey_analysis_mvp/report_template.html
@@ -24,18 +24,26 @@
       </section>
     </div>
 
-    <div class="two-column">
-      <div>
-        <h2>主要トピック</h2>
-        <div class="chart-container">
-          <img src="{{ wordcloud_path }}" alt="ワードクラウド" />
+      <div class="two-column">
+        <div>
+          <h2>主要トピック</h2>
+          <div class="chart-container">
+            {% if positive_wordcloud_path %}
+            <img src="{{ positive_wordcloud_path }}" alt="ポジティブワードクラウド" />
+            {% endif %}
+            {% if negative_wordcloud_path %}
+            <img src="{{ negative_wordcloud_path }}" alt="ネガティブワードクラウド" />
+            {% endif %}
+            {% if wordcloud_path %}
+            <img src="{{ wordcloud_path }}" alt="ワードクラウド" />
+            {% endif %}
+          </div>
         </div>
+        <section>
+          <h2>ネガティブ要約</h2>
+          <p>{{ negative_summary }}</p>
+        </section>
       </div>
-      <section>
-        <h2>ネガティブ要約</h2>
-        <p>{{ negative_summary }}</p>
-      </section>
-    </div>
 
     <div class="table-container">
         <h3>トピック一覧</h3>

--- a/coding/survey_analysis_mvp/reporting.py
+++ b/coding/survey_analysis_mvp/reporting.py
@@ -280,27 +280,51 @@ def create_report(
     plt.close()
 
     # 2. word cloud
+    wordcloud_path = ""
+    positive_wc_path = ""
+    negative_wc_path = ""
     if wordcloud_type == "normal":
         texts = df[text_column].fillna("").astype(str)
-    elif wordcloud_type == "positive":
-        texts = (
+        wc = WordCloud(
+            width=800, height=400, background_color="white", font_path=FONT_REGULAR_PATH
+        )
+        wc.generate(" ".join(texts))
+        wordcloud_path = os.path.join(output_dir, "wordcloud.png")
+        wc.to_file(wordcloud_path)
+    else:
+        # Positive word cloud
+        texts_pos = (
             df[df["sentiment"].isin(["positive", "neutral"])][text_column]
             .fillna("")
             .astype(str)
         )
-    else:
-        texts = (
+        if not texts_pos.empty:
+            wc_pos = WordCloud(
+                width=800,
+                height=400,
+                background_color="white",
+                font_path=FONT_REGULAR_PATH,
+            )
+            wc_pos.generate(" ".join(texts_pos))
+            positive_wc_path = os.path.join(output_dir, "positive_wordcloud.png")
+            wc_pos.to_file(positive_wc_path)
+
+        # Negative word cloud
+        texts_neg = (
             df[df["sentiment"].isin(["negative", "neutral"])][text_column]
             .fillna("")
             .astype(str)
         )
-
-    wc = WordCloud(
-        width=800, height=400, background_color="white", font_path=FONT_REGULAR_PATH
-    )
-    wc.generate(" ".join(texts))
-    wc_path = os.path.join(output_dir, "wordcloud.png")
-    wc.to_file(wc_path)
+        if not texts_neg.empty:
+            wc_neg = WordCloud(
+                width=800,
+                height=400,
+                background_color="white",
+                font_path=FONT_REGULAR_PATH,
+            )
+            wc_neg.generate(" ".join(texts_neg))
+            negative_wc_path = os.path.join(output_dir, "negative_wordcloud.png")
+            wc_neg.to_file(negative_wc_path)
 
     # 3. render HTML via Jinja2
     env = Environment(loader=FileSystemLoader(os.path.dirname(__file__)))
@@ -309,7 +333,9 @@ def create_report(
         "positive_summary": positive_summary,
         "negative_summary": negative_summary,
         "sentiment_chart_path": chart_path,
-        "wordcloud_path": wc_path,
+        "wordcloud_path": wordcloud_path,
+        "positive_wordcloud_path": positive_wc_path,
+        "negative_wordcloud_path": negative_wc_path,
         "total_count": len(df),
     }
     html_out = template.render(**context)


### PR DESCRIPTION
## Summary
- create positive and negative word clouds when requested
- pass new paths to the Jinja2 template
- show both word cloud images in the report template when available

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886012faaa8833391226583a0664f49