### PR TITLE
Add wordcloud images to PDF reports

### DIFF
--- a/coding/survey_analysis_mvp/main.py
+++ b/coding/survey_analysis_mvp/main.py
@@ -220,7 +220,7 @@ class App(ctk.CTk):
         )
         if path:
             try:
-                generate_pdf_report(self.summary_data, path)
+                generate_pdf_report(self.summary_data, path, None, None)
                 messagebox.showinfo("成功", f"PDFレポートを {path} に保存しました。")
             except Exception as e:
                 messagebox.showerror("保存エラー", f"PDFの保存に失敗しました:\n{e}")


### PR DESCRIPTION
## Summary
- include wordcloud image paths in `create_report` summary
- extend `generate_pdf_report` to handle positive/negative wordcloud images
- update GUI save logic to pass new arguments

## Testing
- `black coding/survey_analysis_mvp/reporting.py coding/survey_analysis_mvp/main.py`
- `python scripts/compile_all.py`

------
https://chatgpt.com/codex/tasks/task_e_688a98301c208333a695a2e54d909aa9