### PR TITLE
Combine report summaries

### DIFF
--- a/coding/survey_analysis_mvp/reporting.py
+++ b/coding/survey_analysis_mvp/reporting.py
@@ -400,10 +400,20 @@ def create_report(
         neg_wc = os.path.join(output_dir, "negative_wordcloud.png")
 
     # --- PDF report ------------------------------------------------------
+    # Combine positive and negative summaries for the overall summary text
+    summary_text = "\n\n".join(
+        s.strip() for s in [positive_summary, negative_summary] if s.strip()
+    )
+
+    # Derive action items from the negative summary lines
+    action_items = [
+        line.strip("・- ") for line in negative_summary.splitlines() if line.strip()
+    ]
+
     summary = {
         "analysis_target": f"「{column_name}」列の回答",
-        "summary_text": positive_summary,
-        "action_items": [negative_summary],
+        "summary_text": summary_text,
+        "action_items": action_items or ["アクションアイテムがありません。"],
         "sentiment_counts": counts,
         "pos_wc": pos_wc,
         "neg_wc": neg_wc,


### PR DESCRIPTION
## Summary
- combine positive and negative summaries when building PDF content
- derive action items from negative summary lines

## Testing
- `python scripts/compile_all.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c46b70520833392e17bdfb928e54a