### PR TITLE
Add tests for report generation and dataframe analysis

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -11,3 +11,6 @@
 ## 2025-08-01
 - Re-installed dependencies.
 - compile_all and pytest successful.
+
+## 2025-08-02
+- Added tests for PDF report generation and analyze_dataframe.

--- a/tests/test_analyze_dataframe.py
+++ b/tests/test_analyze_dataframe.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import pandas as pd
+import asyncio
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+MODULE_DIR = os.path.join(BASE_DIR, "coding", "survey_analysis_mvp")
+sys.path.insert(0, MODULE_DIR)
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import analysis
+from analysis import (
+    SurveyResponseAnalysis,
+    ModerationCategories,
+    ModerationScores,
+    ModerationResult,
+    EmotionScores,
+    ComprehensiveAnalysisResult,
+)
+
+
+async def fake_analyze_single_text(text: str, mode: str = "B") -> ComprehensiveAnalysisResult:
+    return ComprehensiveAnalysisResult(
+        survey_analysis=SurveyResponseAnalysis(
+            sentiment="positive",
+            key_topics=["topic"],
+            verbatim_quote="quote",
+            actionable_insight=False,
+        ),
+        moderation_result=ModerationResult(
+            flagged=False,
+            categories=ModerationCategories(
+                hate=False,
+                hate_threatening=False,
+                self_harm=False,
+                sexual=False,
+                sexual_minors=False,
+                violence=False,
+                violence_graphic=False,
+            ),
+            category_scores=ModerationScores(
+                hate=0.0,
+                hate_threatening=0.0,
+                self_harm=0.0,
+                sexual=0.0,
+                sexual_minors=0.0,
+                violence=0.0,
+                violence_graphic=0.0,
+            ),
+        ),
+        emotion_scores=EmotionScores(
+            joy=1.0,
+            sadness=0.0,
+            fear=0.0,
+            surprise=0.0,
+            anger=0.0,
+            disgust=0.0,
+            reason="",
+        ),
+    )
+
+
+def test_analyze_dataframe(monkeypatch):
+    df = pd.DataFrame({"text": ["a", "b"]})
+    monkeypatch.setattr(analysis, "analyze_single_text", fake_analyze_single_text)
+    result = asyncio.run(analysis.analyze_dataframe(df, "text", max_concurrent_tasks=2))
+    assert "analysis_sentiment" in result.columns
+    assert len(result) == 2
+    assert all(result["analysis_sentiment"] == "positive")

--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import pandas as pd
+
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+MODULE_DIR = os.path.join(BASE_DIR, "coding", "survey_analysis_mvp")
+sys.path.insert(0, MODULE_DIR)
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+import reporting
+
+
+def test_generate_pdf_report(tmp_path):
+    summary = {
+        "analysis_target": "Test Column",
+        "summary_text": "dummy summary",
+        "action_items": [],
+        "sentiment_counts": pd.Series([1, 0, 0], index=["positive", "neutral", "negative"]),
+        "topic_counts": pd.Series([2], index=["Topic"]),
+    }
+    output_pdf = tmp_path / "report.pdf"
+    reporting.generate_pdf_report(summary, str(output_pdf))
+    assert output_pdf.exists()


### PR DESCRIPTION
## Summary
- add unit test for `generate_pdf_report`
- add unit test for `analyze_dataframe` using mocked async analysis
- log new tests in `WORKLOG.md`

## Testing
- `python scripts/compile_all.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c76cb6ef483339ab76ed54951e6cc